### PR TITLE
Fix resource management and topic initialization

### DIFF
--- a/src/test/scala/kafka/reactive/KafkaNoProducerNoRestartTest.scala
+++ b/src/test/scala/kafka/reactive/KafkaNoProducerNoRestartTest.scala
@@ -1,18 +1,19 @@
 package kafka.reactive
 
+import java.util.concurrent.TimeUnit
+
 import akka.actor.ActorSystem
 import akka.kafka.scaladsl._
 import akka.kafka.{ConsumerSettings, ProducerSettings}
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{Sink, Source}
-import net.manub.embeddedkafka.EmbeddedKafkaConfig
+import akka.testkit.TestKit
+import net.manub.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig}
 import org.apache.curator.test.InstanceSpec
 import org.apache.kafka.clients.consumer.ConsumerConfig
-import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
+import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.serialization.{StringDeserializer, StringSerializer}
 import org.scalatest._
-import net.manub.embeddedkafka.EmbeddedKafka
-
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
@@ -30,12 +31,13 @@ class KafkaNoProducerNoRestartTest extends WordSpec with BeforeAndAfter with Bef
   }
 
   override protected def afterAll(): Unit = {
+    TestKit.shutdownActorSystem(system, verifySystemShutdown = true)
     EmbeddedKafka.stop()
-    system.terminate()
   }
 
   "Kafka" should {
     "send and receive a single message" in {
+      givenInitializedTopic("topic1")
       val message: String = "some message"
 
       Source.single(message)
@@ -44,21 +46,25 @@ class KafkaNoProducerNoRestartTest extends WordSpec with BeforeAndAfter with Bef
         .run()
 
       val future = Consumer.plainSource(localConsumerSettingsOn(port, Set("topic1")))
+        .map(_.value())
+        .filterNot(_ == "InitialMsg")
         .runWith(Sink.head)
-        .map(record => new String(record.value()))
+
 
       Await.result(future, 3.seconds) should ===(message)
     }
 
     "send and receive multiple messages" in {
-      val kafkaProducer: KafkaProducer[String, String] = localProducerSettingsOn(port).createKafkaProducer()
-
-      kafkaProducer.send(new ProducerRecord[String, String]("topic2", "message1"))
-      kafkaProducer.send(new ProducerRecord[String, String]("topic2", "message2"))
-      kafkaProducer.send(new ProducerRecord[String, String]("topic2", "message3"))
+      givenInitializedTopic("topic2")
+      Source(1 to 4)
+        .map("message" + _.toString)
+        .map(elem => new ProducerRecord[String, String]("topic2", elem))
+        .to(Producer.plainSink(localProducerSettingsOn(port)))
+        .run()
 
       val future = Consumer.plainSource(localConsumerSettingsOn(port, Set("topic2")))
-        .map(record => new String(record.value()))
+        .map(_.value())
+        .filterNot(_ == "InitialMsg")
         .take(3)
         .runFold(Array.empty[String])((arr, s) => arr :+ s)
 
@@ -66,6 +72,11 @@ class KafkaNoProducerNoRestartTest extends WordSpec with BeforeAndAfter with Bef
     }
   }
 
+  def givenInitializedTopic(topic: String): Unit = {
+    val producer = localProducerSettingsOn(port).createKafkaProducer()
+    producer.send(new ProducerRecord(topic, 0, null: String, "InitialMsg"))
+    producer.close(60, TimeUnit.SECONDS)
+  }
   private def localConsumerSettingsOn(port: Int, topic: Set[String]): ConsumerSettings[String, String] = {
     ConsumerSettings(system, new StringDeserializer, new StringDeserializer, topic)
       .withBootstrapServers(s"127.0.0.1:$port")

--- a/src/test/scala/kafka/reactive/KafkaReactiveNoRestartTest.scala
+++ b/src/test/scala/kafka/reactive/KafkaReactiveNoRestartTest.scala
@@ -1,18 +1,22 @@
 package kafka.reactive
 
+
+import java.util.concurrent.TimeUnit
+
 import akka.actor.ActorSystem
 import akka.kafka.scaladsl._
 import akka.kafka.{ConsumerSettings, ProducerSettings}
 import akka.stream.ActorMaterializer
-import akka.stream.scaladsl.{Sink, Source}
+import akka.stream.scaladsl.Source
+import akka.stream.testkit.javadsl.TestSink
+import akka.testkit.TestKit
+import net.manub.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig}
 import org.apache.curator.test.InstanceSpec
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.serialization.{StringDeserializer, StringSerializer}
 import org.scalatest._
-import net.manub.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig}
 
-import scala.concurrent.Await
 import scala.concurrent.duration._
 
 class KafkaReactiveNoRestartTest extends WordSpec with BeforeAndAfter with BeforeAndAfterAll with Matchers {
@@ -29,12 +33,13 @@ class KafkaReactiveNoRestartTest extends WordSpec with BeforeAndAfter with Befor
   }
 
   override protected def afterAll(): Unit = {
+    TestKit.shutdownActorSystem(system, verifySystemShutdown = true)
     EmbeddedKafka.stop()
-    system.terminate()
   }
 
   "Kafka" should {
     "send and receive a single message" in {
+      givenInitializedTopic("topic1")
       val message: String = "some message"
 
       Source.single(message)
@@ -42,28 +47,50 @@ class KafkaReactiveNoRestartTest extends WordSpec with BeforeAndAfter with Befor
         .to(Producer.plainSink(localProducerSettingsOn(port)))
         .run()
 
-      val future = Consumer.plainSource(localConsumerSettingsOn(port, Set("topic1")))
-        .runWith(Sink.head)
+      val probe = Consumer.plainSource(localConsumerSettingsOn(port, Set("topic1")))
         .map(record => new String(record.value()))
+        // it's not 100% sure we get the first message, see https://issues.apache.org/jira/browse/KAFKA-3334
+        .filterNot(_ == "InitialMsg")
+        .runWith(TestSink.probe(system))
 
-      Await.result(future, 3.seconds) should ===(message)
+      probe
+        .request(1)
+        .expectNext(10.seconds, "some message")
+
+      probe.cancel()
     }
 
     "send and receive multiple messages" in {
+      givenInitializedTopic("topic2")
+
       Source(1 to 3)
         .map("message" + _.toString)
         .map(elem => new ProducerRecord[String, String]("topic2", elem))
         .to(Producer.plainSink(localProducerSettingsOn(port)))
         .run()
 
-      val future = Consumer.plainSource(localConsumerSettingsOn(port, Set("topic2")))
+      val probe = Consumer.plainSource(localConsumerSettingsOn(port, Set("topic2")))
         .map(record => new String(record.value()))
-        .take(3)
-        .runFold(Array.empty[String])((arr, s) => arr :+ s)
+        // it's not 100% sure we get the first message, see https://issues.apache.org/jira/browse/KAFKA-3334
+        .filterNot(_ == "InitialMsg")
+        .runWith(TestSink.probe(system))
 
-      Await.result(future, 3.seconds) should contain allOf("message1", "message2", "message3")
+      probe
+        .request(3)
+        .expectNext(100.seconds, "message1")
+        .expectNext(10.seconds, "message2")
+        .expectNext(10.seconds, "message3")
+
+      probe.cancel()
     }
   }
+
+  def givenInitializedTopic(topic: String): Unit = {
+    val producer = localProducerSettingsOn(port).createKafkaProducer()
+    producer.send(new ProducerRecord(topic, 0, null: String, "InitialMsg"))
+    producer.close(60, TimeUnit.SECONDS)
+  }
+
 
   private def localConsumerSettingsOn(port: Int, topic: Set[String]): ConsumerSettings[String, String] = {
     ConsumerSettings(system, new StringDeserializer, new StringDeserializer, topic)


### PR DESCRIPTION
This PR adds some examples of how your tests can be tuned in order to work correctly:
1. Use `TestProbe.sink` and cancel it.
2. Use `TestKit.shutdownActorSystem` and prefer to call it before closing Embedded Kafka to avoid errors in logs.
3. Initialize topics. Connecting to non-existing topic with a consumer before it's initialized by a producer was causing problems like https://github.com/akka/reactive-kafka/issues/156
